### PR TITLE
fix hidden NoClassDefFoundError

### DIFF
--- a/src/main/java/vip/fubuki/playersync/sync/ModsSupport.java
+++ b/src/main/java/vip/fubuki/playersync/sync/ModsSupport.java
@@ -3,6 +3,7 @@ package vip.fubuki.playersync.sync;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fml.ModList;
@@ -170,4 +171,32 @@ public class ModsSupport {
             JDBCsetUp.executeUpdate("UPDATE curios SET curios_item = '" + serializedData + "' WHERE uuid = '" + player.getUUID() + "'");
         }
     }
+
+    public static void storeSophisticatedBackpacks(Player player) {
+        PlayerSync.LOGGER.info("Storing backpack data for player " + player.getUUID());
+        net.p3pp3rf1y.sophisticatedbackpacks.util.PlayerInventoryProvider.get().runOnBackpacks(player, (ItemStack backpackItem, String handler, String identifier, int slot) -> {
+            backpackItem.getCapability(net.p3pp3rf1y.sophisticatedbackpacks.api.CapabilityBackpackWrapper.getCapabilityInstance())
+                    .ifPresent(wrapper -> {
+                        // Retrieve the contents UUID from the backpack's NBT using NBTHelper
+                        Optional<UUID> uuidOpt = net.p3pp3rf1y.sophisticatedcore.util.NBTHelper.getUniqueId(wrapper.getBackpack(), "contentsUuid");
+                        if (uuidOpt.isPresent()) {
+                            UUID contentsUuid = uuidOpt.get();
+                            // Get internal backpack data from BackpackStorage (creates it if missing)
+                            CompoundTag backpackNbt = net.p3pp3rf1y.sophisticatedbackpacks.backpack.BackpackStorage.get().getOrCreateBackpackContents(contentsUuid);
+                            String serialized = VanillaSync.serialize(backpackNbt.toString());
+                            try {
+                                // Use REPLACE INTO so existing records are updated
+                                JDBCsetUp.executeUpdate("REPLACE INTO backpack_data (uuid, backpack_nbt) VALUES ('" + contentsUuid.toString() + "', '" + serialized + "')");
+                                PlayerSync.LOGGER.info("Saved backpack data for UUID " + contentsUuid);
+                            } catch (SQLException e) {
+                                PlayerSync.LOGGER.error("Error saving backpack data for UUID " + contentsUuid, e);
+                            }
+                        } else {
+                            PlayerSync.LOGGER.warn("Backpack item in slot " + slot + " has no contentsUuid");
+                        }
+                    });
+            return false; // Continue processing all backpack items.
+        });
+    }
+
 }

--- a/src/main/java/vip/fubuki/playersync/sync/VanillaSync.java
+++ b/src/main/java/vip/fubuki/playersync/sync/VanillaSync.java
@@ -31,6 +31,7 @@ import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.server.ServerStoppedEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.server.ServerLifecycleHooks;
 import vip.fubuki.playersync.PlayerSync;
@@ -286,32 +287,9 @@ public class VanillaSync {
             ender_chest.put(i, serialize(itemNBT.toString()));
         }
 
-        // --- Begin Backpack Data Sync (Store) ---
-        PlayerSync.LOGGER.info("Storing backpack data for player " + player.getUUID());
-        net.p3pp3rf1y.sophisticatedbackpacks.util.PlayerInventoryProvider.get().runOnBackpacks(player, (ItemStack backpackItem, String handler, String identifier, int slot) -> {
-            backpackItem.getCapability(net.p3pp3rf1y.sophisticatedbackpacks.api.CapabilityBackpackWrapper.getCapabilityInstance())
-                    .ifPresent(wrapper -> {
-                        // Retrieve the contents UUID from the backpack's NBT using NBTHelper
-                        Optional<UUID> uuidOpt = net.p3pp3rf1y.sophisticatedcore.util.NBTHelper.getUniqueId(wrapper.getBackpack(), "contentsUuid");
-                        if (uuidOpt.isPresent()) {
-                            UUID contentsUuid = uuidOpt.get();
-                            // Get internal backpack data from BackpackStorage (creates it if missing)
-                            CompoundTag backpackNbt = net.p3pp3rf1y.sophisticatedbackpacks.backpack.BackpackStorage.get().getOrCreateBackpackContents(contentsUuid);
-                            String serialized = VanillaSync.serialize(backpackNbt.toString());
-                            try {
-                                // Use REPLACE INTO so existing records are updated
-                                JDBCsetUp.executeUpdate("REPLACE INTO backpack_data (uuid, backpack_nbt) VALUES ('" + contentsUuid.toString() + "', '" + serialized + "')");
-                                PlayerSync.LOGGER.info("Saved backpack data for UUID " + contentsUuid);
-                            } catch (SQLException e) {
-                                PlayerSync.LOGGER.error("Error saving backpack data for UUID " + contentsUuid, e);
-                            }
-                        } else {
-                            PlayerSync.LOGGER.warn("Backpack item in slot " + slot + " has no contentsUuid");
-                        }
-                    });
-            return false; // Continue processing all backpack items.
-        });
-        // --- End Backpack Data Sync (Store) ---
+        if(ModList.get().isLoaded("sophisticatedbackpacks")){
+            ModsSupport.storeSophisticatedBackpacks(player);
+        }
 
         // Effects
         Map<MobEffect, MobEffectInstance> effects = player.getActiveEffectsMap();


### PR DESCRIPTION
net.p3pp3rf1y.sophisticatedbackpacks throws a NoClassDefFoundError when sophisticated backpacks is not installed.
This exception never reaches the logs for unknown reasons.

Checking explicitly for `ModList.get().isLoaded()` ensures that the mod is loaded.

Otherwise, the current logic is unmodified.

Fixes regression of 439c7ee5bba1728d60d715c3f7b7c08dd02ff6bd / 1.3.5