### PR TITLE
fix armor duping

### DIFF
--- a/src/main/java/vip/fubuki/playersync/sync/VanillaSync.java
+++ b/src/main/java/vip/fubuki/playersync/sync/VanillaSync.java
@@ -269,7 +269,6 @@ public class VanillaSync {
         Map<Integer, String> equipment = new HashMap<>();
         for (int i = 0; i < player.getInventory().armor.size(); i++) {
             ItemStack itemStack = player.getInventory().armor.get(i);
-            if (itemStack.isEmpty()) continue;
             equipment.put(i, serialize(itemStack.serializeNBT().toString()));
         }
         // Inventory


### PR DESCRIPTION
The continue "skipped" the armor entries in the database instead of writing an explicit "air" item into the slot.

When restoring, only existing entries are being restored, all other items are left untouched. Allowing to dupe items in armor slots.

Potentially addresses #29 