### PR TITLE
Improve dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,7 @@ dependencies {
     // This maps to ./libs/coolmod-${mc_version}-${coolmod_version}.jar
     // The group id is ignored when searching -- in this case, it is "blank"
     compileOnly fg.deobf("curse.maven:curios-309927:5266541")
-    runtimeOnly fg.deobf("curse.maven:MySQL-561280:3685108")
+    runtimeOnly fg.deobf("curse.maven:MySQL-561280:4684944")
     compileOnly fg.deobf("curse.maven:sophisticated-backpacks-422301:6303388")
     compileOnly fg.deobf("curse.maven:sophisticated-core-618298:6317048")
 

--- a/build.gradle
+++ b/build.gradle
@@ -149,10 +149,10 @@ dependencies {
     // Example mod dependency using a mod jar from ./libs with a flat dir repository
     // This maps to ./libs/coolmod-${mc_version}-${coolmod_version}.jar
     // The group id is ignored when searching -- in this case, it is "blank"
-    implementation fg.deobf("curse.maven:curios-309927:5266541")
-    implementation fg.deobf("curse.maven:MySQL-561280:3685108")
-    implementation fg.deobf("curse.maven:sophisticated-backpacks-422301:6303388")
-    implementation fg.deobf("curse.maven:sophisticated-core-618298:6317048")
+    compileOnly fg.deobf("curse.maven:curios-309927:5266541")
+    runtimeOnly fg.deobf("curse.maven:MySQL-561280:3685108")
+    compileOnly fg.deobf("curse.maven:sophisticated-backpacks-422301:6303388")
+    compileOnly fg.deobf("curse.maven:sophisticated-core-618298:6317048")
 
     // For more info:
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -66,6 +66,14 @@ description='''${mod_description}'''
     ordering="NONE"
     side="BOTH"
 
+# Dependency for MySQL
+[[dependencies.${mod_id}]]
+    modId="mysql_jdbc"
+    mandatory=true
+    versionRange="[8.0.33+20230506,)"
+    ordering="NONE"
+    side="SERVER"
+
 # Features are specific properties of the game environment, that you may want to declare you require. This example declares
 # that your mod requires GL version 3.2 or higher. Other features will be added. They are side aware so declaring this won't
 # stop your mod loading on the server for example.


### PR DESCRIPTION
With this PR it 
- will be possible to do a `./gradlew runServer` again, assuming you have a MySQL database running.
- also makes sure that the mysql jdbc driver is installed on the server and fails transparently.
- fixes errors about "incompatible mod set" because of the mysql mod according to [their release](https://github.com/kosmolot-mods/minecraft-mysql-jdbc/releases/tag/8.0.30%2B20220916).