### PR TITLE
Add docker compose for MySQL setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,63 @@
 # PlayerSync
-This is a Minecraft forge mod using Mysql backend to make player data synchronization between different servers.  
-Such as equipment,inventory,effects,experience,food level.Any other mods support is also possible.  
-Support version now:  
-1.20.1
-1.19-1.19.3  
-1.18.2  
-1.16.5  
-Current support Mod:
-curios
+
+PlayerSync is a Minecraft Forge mod that synchronizes player data across multiple servers using a MySQL backend. It allows players to maintain their inventory, equipment, experience, advancements, and more when moving between servers in a network.
+
+## Mod Support
+*   [Curios API](https://www.curseforge.com/minecraft/mc-mods/curios)
+*   [Sophisticated Backpacks](https://www.curseforge.com/minecraft/mc-mods/sophisticated-backpacks)
+
+Any other mods support is also possible.
+
+## Development Setup
+
+### Database Setup (Docker)
+
+A `docker-compose.yml` file is provided for easily setting up a MariaDB database instance for development testing.
+
+1.  Make sure Docker is installed.
+1.  Inside your work directory run:
+    ```sh
+    docker compose up -d
+    ```
+    This will download the MariaDB image (if not already present) and start a database container in the background.
+1.  Stoppinng the Database
+    ```sh
+    docker compose down
+    ```
+
+**Data Persistence:** The database uses a Docker volume, ensuring your data persists even if you stop and restart the containers.
+
+#### Database Management Tool
+The `docker-compose.yml` also includes an [Adminer](https://www.adminer.org/) service, a lightweight database management tool.
+
+* Access Adminer in your web browser at http://localhost:8080.
+* Log in using the server with
+  - username: `playersync`
+  - database: `playersync`
+  - password: see [docker-compose.yml](./docker-compose.yml)
+
+For debugging purposes, you can enable `use_legacy_serialization` to have readable database fields. This can cause crashes and unintended side-effects. **Do not enable this on a production server if not absolutely necessary!**
+
+
+### Running the Mod
+
+The project uses Gradle for building and running. Use the provided Gradle wrapper (`gradlew` for Linux/macOS, `gradlew.bat` for Windows).
+
+1.  Make sure that the MySQL database you configured is running.
+1.  Run the Server
+    ```sh
+    ./gradlew runServer
+    ```
+    or on Windows:
+    ```bat
+    .\gradlew.bat runServer
+    ```
+    This task compiles the mod and starts a dedicated Minecraft server instance with the mod loaded in the `run` directory.
+1.  Run the Client
+    ```sh
+    ./gradlew runClient
+    ```
+    or on Windows:
+    ```bat
+    .\gradlew.bat runClient
+    ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+
+  db:
+    image: mariadb
+    restart: unless-stopped
+    environment:
+      MARIADB_DATABASE: playersync
+      MARIADB_USER: playersync
+      MARIADB_PASSWORD: pleaseChangeThisPassword  # It is strongly recommended to change this password outside of local development
+      MARIADB_RANDOM_ROOT_PASSWORD: True
+
+  adminer:
+    image: adminer
+    restart: unless-stopped
+    ports:
+      - 8080:8080

--- a/src/main/java/vip/fubuki/playersync/config/JdbcConfig.java
+++ b/src/main/java/vip/fubuki/playersync/config/JdbcConfig.java
@@ -32,8 +32,8 @@ public class JdbcConfig {
         HOST=COMMON_BUILDER.comment("The host of the database").define("host", "localhost");
         PORT = COMMON_BUILDER.comment("database port").defineInRange("db_port", 3306, 0, 65535);
         USE_SSL = COMMON_BUILDER.comment("whether use SSL").define("use_ssl", false);
-        USERNAME = COMMON_BUILDER.comment("username").define("user_name", "root");
-        PASSWORD = COMMON_BUILDER.comment("password").define("password", "password");
+        USERNAME = COMMON_BUILDER.comment("username").define("user_name", "playersync");
+        PASSWORD = COMMON_BUILDER.comment("password").define("password", "pleaseChangeThisPassword");
         DATABASE_NAME = COMMON_BUILDER.comment("database name").define("db_name","playersync");
         SERVER_ID = COMMON_BUILDER.comment("the server id should be unique").define("Server_id", new Random().nextInt(1,Integer.MAX_VALUE-1));
         SYNC_WORLD = COMMON_BUILDER.comment("The worlds that will be synchronized.If running in server it is supposed to have only one").define("sync_world", new ArrayList<>());


### PR DESCRIPTION
This adds a docker compose file that to start a local MariaDB and can be use together with a `./gradlew runClient` or `./gradlew runServer` for local testing.