### PR TITLE
make advancement sync optional

### DIFF
--- a/src/main/java/vip/fubuki/playersync/config/JdbcConfig.java
+++ b/src/main/java/vip/fubuki/playersync/config/JdbcConfig.java
@@ -16,6 +16,7 @@ public class JdbcConfig {
     public static ForgeConfigSpec.ConfigValue<String> PASSWORD;
     public static ForgeConfigSpec.ConfigValue<String> DATABASE_NAME;
     public static ForgeConfigSpec.ConfigValue<List<String>> SYNC_WORLD;
+    public static ForgeConfigSpec.BooleanValue SYNC_ADVANCEMENTS;
     public static ForgeConfigSpec.BooleanValue USE_SSL;
     public static ForgeConfigSpec.BooleanValue SYNC_CHAT;
     public static ForgeConfigSpec.BooleanValue IS_CHAT_SERVER;
@@ -37,6 +38,8 @@ public class JdbcConfig {
         DATABASE_NAME = COMMON_BUILDER.comment("database name").define("db_name","playersync");
         SERVER_ID = COMMON_BUILDER.comment("the server id should be unique").define("Server_id", new Random().nextInt(1,Integer.MAX_VALUE-1));
         SYNC_WORLD = COMMON_BUILDER.comment("The worlds that will be synchronized. If running on a server, leave array empty.").define("sync_world", new ArrayList<>());
+        SYNC_ADVANCEMENTS = COMMON_BUILDER.comment("Whether to sync advancements between servers")
+                .define("sync_advancements", true);
         SYNC_CHAT= COMMON_BUILDER.comment("Whether synchronize chat").define("sync_chat", true);
         IS_CHAT_SERVER = COMMON_BUILDER.comment("Whether recieve messages from other servers as host").define("IsChatServer",false);
         CHAT_SERVER_IP = COMMON_BUILDER.define("ChatServerIP","127.0.0.1");

--- a/src/main/java/vip/fubuki/playersync/sync/VanillaSync.java
+++ b/src/main/java/vip/fubuki/playersync/sync/VanillaSync.java
@@ -48,6 +48,9 @@ public class VanillaSync {
 
     @SubscribeEvent
     public static void onDataPackSyncEvent(OnDatapackSyncEvent event) throws SQLException, IOException {
+        if (!JdbcConfig.SYNC_ADVANCEMENTS.get())
+            return; // advancement sync disabled
+
         final ServerPlayer serverPlayer = event.getPlayer();
         if (serverPlayer == null) {
             PlayerSync.LOGGER.debug("No player joining");
@@ -364,33 +367,36 @@ public class VanillaSync {
             CompoundTag effectTag = entry.getValue().save(new CompoundTag());
             effectMap.put(MobEffect.getId(entry.getKey()), serialize(effectTag.toString()));
         }
+
         // Advancements
         File advancements = null;
-        File gameDir = Objects.requireNonNull(player.getServer()).getServerDirectory();
-        final MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
-        if (server != null && server.isDedicatedServer() ) {
-            PlayerSync.LOGGER.trace("Reading dedicated server advancements");
-            advancements = new File(gameDir, getSyncWorldForServer() + "/advancements" + "/" + player_uuid + ".json");
-        } else {
-            PlayerSync.LOGGER.debug("Reading non-dedicated server advancements");
-            File[] files = scanAdvancementsFile(player_uuid, gameDir);
-            long latestModifiedDate = 0;
-            for (File file : files) {
-                if (file == null) continue;
-                if (file.lastModified() > latestModifiedDate) {
-                    latestModifiedDate = file.lastModified();
-                    advancements = file;
+        byte[] advancementBytes = new byte[0];
+        if (JdbcConfig.SYNC_ADVANCEMENTS.get()) {
+            File gameDir = Objects.requireNonNull(player.getServer()).getServerDirectory();
+            final MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
+            if (server != null && server.isDedicatedServer() ) {
+                PlayerSync.LOGGER.trace("Reading dedicated server advancements");
+                advancements = new File(gameDir, getSyncWorldForServer() + "/advancements" + "/" + player_uuid + ".json");
+            } else {
+                PlayerSync.LOGGER.debug("Reading non-dedicated server advancements");
+                File[] files = scanAdvancementsFile(player_uuid, gameDir);
+                long latestModifiedDate = 0;
+                for (File file : files) {
+                    if (file == null) continue;
+                    if (file.lastModified() > latestModifiedDate) {
+                        latestModifiedDate = file.lastModified();
+                        advancements = file;
+                    }
                 }
             }
+            if (advancements != null) {
+                PlayerSync.LOGGER.debug("Storing advancements for " + player_uuid + " from " + advancements.toPath());
+                advancementBytes = Files.readAllBytes(advancements.toPath());
+            } else {
+                PlayerSync.LOGGER.error("Unable to save advancements for player " + player_uuid);
+            }
         }
-        byte[] bytes = new byte[0];
-        if (advancements != null) {
-            PlayerSync.LOGGER.debug("Storing advancements for " + player_uuid + " from " + advancements.toPath());
-            bytes = Files.readAllBytes(advancements.toPath());
-        } else {
-            PlayerSync.LOGGER.error("Unable to save advancements for player " + player_uuid);
-        }
-        String json = new String(bytes, StandardCharsets.UTF_8);
+        String json = new String(advancementBytes, StandardCharsets.UTF_8);
         PlayerSync.LOGGER.trace("Storing advancements for player " + player_uuid + ": " + json);
 
         // SQL Operation for player data


### PR DESCRIPTION
As advancement sync causes issues if both servers do not have exactly the same advancements, this adds a flag to disable it.