### PR TITLE
fix advancement sync for new players

### DIFF
--- a/src/main/java/vip/fubuki/playersync/sync/VanillaSync.java
+++ b/src/main/java/vip/fubuki/playersync/sync/VanillaSync.java
@@ -389,7 +389,11 @@ public class VanillaSync {
                     }
                 }
             }
-            if (advancements != null) {
+            if (!advancements.exists()) {
+                PlayerSync.LOGGER.warn("Advancements file for " + player_uuid + " does not exist (yet).");
+            }
+
+            if (advancements != null && advancements.exists()) {
                 PlayerSync.LOGGER.debug("Storing advancements for " + player_uuid + " from " + advancements.toPath());
                 advancementBytes = Files.readAllBytes(advancements.toPath());
             } else {


### PR DESCRIPTION
On dedicated servers, advancements are not written when a new player joins but we try to read the file after a few ticks already.
The file will be written latest when the player logs off.