### PR TITLE
fix chat sync always being enabled

### DIFF
--- a/src/main/java/vip/fubuki/playersync/PlayerSync.java
+++ b/src/main/java/vip/fubuki/playersync/PlayerSync.java
@@ -35,10 +35,14 @@ public class PlayerSync {
 
     private void commonSetup(final FMLCommonSetupEvent event) {
         VanillaSync.register();
-        if (JdbcConfig.SYNC_CHAT.get()) {
-            LOGGER.info("Chat sync enabled.");
-            ChatSync.register();
-        }
+        event.enqueueWork(() -> {
+            // read SYNC_CHAT only within the enqueueWork to reliably get the real
+            // config value and not its default value.
+            if (JdbcConfig.SYNC_CHAT.get()) {
+                LOGGER.info("Chat sync enabled.");
+                ChatSync.register();
+            }
+        });
     }
 
     @SubscribeEvent

--- a/src/main/java/vip/fubuki/playersync/PlayerSync.java
+++ b/src/main/java/vip/fubuki/playersync/PlayerSync.java
@@ -36,6 +36,7 @@ public class PlayerSync {
     private void commonSetup(final FMLCommonSetupEvent event) {
         VanillaSync.register();
         if (JdbcConfig.SYNC_CHAT.get()) {
+            LOGGER.info("Chat sync enabled.");
             ChatSync.register();
         }
     }

--- a/src/main/java/vip/fubuki/playersync/sync/ChatSync.java
+++ b/src/main/java/vip/fubuki/playersync/sync/ChatSync.java
@@ -18,7 +18,12 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.slf4j.Logger;
+
+import com.mojang.logging.LogUtils;
+
 public class ChatSync {
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     static PlayerList playerList;
 
@@ -28,8 +33,10 @@ public class ChatSync {
     static ExecutorService executorService = Executors.newCachedThreadPool();
 
     public static void register(){
-        if(JdbcConfig.IS_CHAT_SERVER.get())
+        if(JdbcConfig.IS_CHAT_SERVER.get()) {
+            LOGGER.info("Launching chat server thread.");
             new Thread(ChatSync::ServerSocket).start();
+        }
         ClientSocket();
         MinecraftForge.EVENT_BUS.register(ChatSync.class);
     }
@@ -37,6 +44,7 @@ public class ChatSync {
 
     private static void ServerSocket() {
         try {
+            LOGGER.info("Trying to setup chat server at port " + JdbcConfig.CHAT_SERVER_PORT.get());
             serverSocket = new ServerSocket(JdbcConfig.CHAT_SERVER_PORT.get());
             while (true) {
                 Socket newSocket = serverSocket.accept();
@@ -44,6 +52,7 @@ public class ChatSync {
                 executorService.submit(() -> handleClient(newSocket));
             }
         } catch (IOException e) {
+            LOGGER.error("Unable to start chat server");
             e.printStackTrace();
         } finally {
             try {
@@ -89,6 +98,10 @@ public class ChatSync {
 
     private static void ClientSocket() {
         try {
+            LOGGER.info("Trying to connect to chat server "
+                    + JdbcConfig.CHAT_SERVER_IP.get()
+                    + ":"
+                    + JdbcConfig.CHAT_SERVER_PORT.get());
             clientSocket = new Socket(JdbcConfig.CHAT_SERVER_IP.get(), JdbcConfig.CHAT_SERVER_PORT.get());
             Scanner scanner = new Scanner(clientSocket.getInputStream());
             while (scanner.hasNextLine()) {
@@ -103,6 +116,7 @@ public class ChatSync {
     }
 
     private static void reconnectClient() {
+        LOGGER.warn("TODO: implement reconnectClient()");
         //TODO
     }
 


### PR DESCRIPTION
Reading `CHAT_SYNC` immediately within `FMLCommonSetupEvent` can lead to
timing issues that the default value instead of the real config value is
being returned.

Thanks a lot to @commoble for the fix.