### PR TITLE
Update deprecated Gradle Actions

### DIFF
--- a/.github/workflows/build-1.20.yml
+++ b/.github/workflows/build-1.20.yml
@@ -23,13 +23,11 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Build
-        id: build
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          arguments: build
-        env:
-          SNAPSHOT: true
+
+      - name: Build with Gradle
+        run: ./gradlew build
 
       - name: Build Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-1.20.yml
+++ b/.github/workflows/build-1.20.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build
         id: build
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v4
         with:
           arguments: build
         env:


### PR DESCRIPTION
I just noticed the two deprecation errors in the last action run:
https://github.com/mlus-asuka/PlayerSync/actions/runs/14812473371

> Deprecation warnings
> This job uses deprecated functionality from the gradle/gradle-build-action action. Follow the links for upgrade details.
[The action `gradle/gradle-build-action` has been replaced by `gradle/actions/setup-gradle`](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle)
[Using the action to execute Gradle via the `arguments` parameter is deprecated](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated)