### PR TITLE
run build CI on all 1.xxx branches

### DIFF
--- a/.github/workflows/build-1.20.yml
+++ b/.github/workflows/build-1.20.yml
@@ -3,7 +3,8 @@ name: Build-1.20
 on:
   pull_request:
   push:
-    branches: [ "1.20.1" ]
+    branches:
+      - '1.**'
 
 jobs:
   build:


### PR DESCRIPTION
@mlus-asuka in preparation for the 1.20.4 branch, I think we can change the branch matching to any "1.xxx" branch. What do you think?