### PR TITLE
bump mod version to 2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ tasks.named('wrapper', Wrapper).configure {
     distributionType = Wrapper.DistributionType.BIN
 }
 
-version = mod_version
+version = minecraft_version + "-" + mod_version
 group = mod_group_id
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ mod_name=PlayerSync
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GPL-3.0 license
 # The mod version. See https://semver.org/
-mod_version=1.20.1-1.3.5
+mod_version=2.0.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html


### PR DESCRIPTION
The field `version` defines how the jar is named, so this should identify itself as version `2.0.0` and the jar is called `playersync-1.20.1-2.0.0.jar`

Fixes #40 