### PR TITLE
Automatic Mod Releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build-1.20
+name: Build
 
 on:
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,13 @@ on:
   push:
     branches:
       - '1.**'
+    tags:
+      - '**'
 
 jobs:
   build:
-
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:
@@ -36,3 +39,15 @@ jobs:
           name: Player_Sync
           path: |
             build/libs/
+
+      - uses: Kir-Antipov/mc-publish@v3.3
+        # run only on tags, no other pushes
+        if: startsWith( github.ref, 'refs/tags' )
+        with:
+          modrinth-id: 4pmkajBP
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+
+          curseforge-id: 737274
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For this to work, you need to create two secrets in the repository at https://github.com/EoD/PlayerSync/settings/secrets/actions/new

- `MODRINTH_TOKEN` a Modrinth token created here: https://modrinth.com/settings/pats
  It requires roughly these permissions ![image](https://github.com/user-attachments/assets/dfc7855c-2b60-4fc7-9b03-d9990c3c2c33)

- `CURSEFORGE_TOKEN` from here https://authors-old.curseforge.com/account/api-tokens (I assume similar permissions)

- `GITHUB_TOKEN` is automatically generated & used

I tested this on my repo and it worked just fine:
1. Triggered by:  https://github.com/EoD/PlayerSync/releases/tag/1.20.1-2.0.0
1. Running: https://github.com/EoD/PlayerSync/actions/runs/14823433966/job/41613536196
1. Test Upload https://modrinth.com/mod/playersync/versions

## **Important**
If you want to upload the mod for multiple versions of Minecraft (like a 2.0.0 release for 1.20.1 and a 2.0.0 for 1.20.4) you need to make sure that each tag is unique. For example, create a tag `1.20.1-2.0.0` on the 1.20.1 branch and `1.20.4-2.0.0` on the 1.20.4 branch.

PS: I also left you a note on Discord