### PR TITLE
[1.20.1] properly upgrade items with newer MC versions

### DIFF
--- a/src/main/java/vip/fubuki/playersync/sync/ModsSupport.java
+++ b/src/main/java/vip/fubuki/playersync/sync/ModsSupport.java
@@ -74,7 +74,7 @@ public class ModsSupport {
                         String serialized = entry.getValue();
                         try {
                             String nbtString = VanillaSync.deserializeString(serialized);
-                            CompoundTag tag = NbtUtils.snbtToStructure(nbtString);
+                            CompoundTag tag = VanillaSync.snbtToFixedCompoundTag(nbtString);
                             ItemStack stack = ItemStack.of(tag);
                             if (handler.getCurios().containsKey(slotType)) {
                                 ICurioStacksHandler stacksHandler = handler.getCurios().get(slotType);

--- a/src/main/java/vip/fubuki/playersync/sync/VanillaSync.java
+++ b/src/main/java/vip/fubuki/playersync/sync/VanillaSync.java
@@ -1,7 +1,9 @@
 package vip.fubuki.playersync.sync;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.serialization.Dynamic;
 import net.minecraft.ChatFormatting;
+import net.minecraft.SharedConstants;
 import net.minecraft.nbt.*;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
@@ -9,6 +11,8 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.PlayerAdvancements;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.datafix.DataFixers;
+import net.minecraft.util.datafix.fixes.References;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -253,7 +257,7 @@ public class VanillaSync {
         }
 
         String nbtString = deserializeString(serializedNbt);
-        CompoundTag compoundTag = NbtUtils.snbtToStructure(nbtString);
+        CompoundTag compoundTag = snbtToFixedCompoundTag(nbtString);
 
         if (compoundTag == null || compoundTag.isEmpty() || !compoundTag.contains("id", Tag.TAG_STRING)) {
             return ItemStack.EMPTY; // Invalid or empty tag
@@ -344,6 +348,23 @@ public class VanillaSync {
         displayTag.put("Lore", loreList);
 
         return placeholder;
+    }
+
+    public static CompoundTag snbtToFixedCompoundTag(String nbtString) throws CommandSyntaxException {
+        CompoundTag parsedTag = TagParser.parseTag(nbtString);
+
+        int currentDataVersion = SharedConstants.getCurrentVersion().getDataVersion().getVersion();
+        int snbtDataVersion = NbtUtils.getDataVersion(parsedTag, 500);
+
+        Dynamic<Tag> dynamicTagInput = new Dynamic<>(NbtOps.INSTANCE, parsedTag);
+
+        Dynamic<Tag> updatedDynamicTag = DataFixers.getDataFixer().update(
+                References.ITEM_STACK,
+                dynamicTagInput,
+                snbtDataVersion,
+                currentDataVersion);
+        CompoundTag compoundTag = (CompoundTag) updatedDynamicTag.getValue();
+        return compoundTag;
     }
 
     /**
@@ -453,6 +474,8 @@ public class VanillaSync {
         // Serialize the ItemStack to NBT
         CompoundTag compoundTag = new CompoundTag();
         itemStack.save(compoundTag);
+        // Adding data version to allow newer version of Minecraft to properly update the itemstack from the db
+        NbtUtils.addCurrentDataVersion(compoundTag);
         return compoundTag;
     }
 


### PR DESCRIPTION
These steps are required for using a 1.20.1 or 1.20.4 database with 1.20.6 and beyond.