### PR TITLE
[Backport 1.20.4] fix string to map generation with base64 encoding 

### DIFF
--- a/src/main/java/vip/fubuki/playersync/util/LocalJsonUtil.java
+++ b/src/main/java/vip/fubuki/playersync/util/LocalJsonUtil.java
@@ -7,11 +7,21 @@ import java.util.function.Function;
 public class LocalJsonUtil {
     private static <K> Map<K, String> stringToGenericMap(String param, Function<String, K> keyParser) {
         Map<K, String> map = new HashMap<>();
-        String s1 = param.substring(1,param.length()-1);
-        String s2 = s1.trim();
-        String[] split = s2.split(",");
-        for (int i = split.length - 1; i >= 0; i--) {
-            String trim = split[i].trim();
+
+        // check if string is at least minimal json
+        if (param == null || param.length() < 2 || param.equals("{}")) {
+            return map;
+        }
+
+        // extract string within outermost json brackets {}
+        String s1 = param.substring(param.indexOf('{')+1, param.lastIndexOf('}')).trim();
+        if (s1.isEmpty()) {
+            return map;
+        }
+
+        // split all json elements
+        for (String split : s1.split(",")) {
+            String trim = split.trim();
 
             // only check for the first "=" as the values also contain additional "="
             int equalIndex = trim.indexOf('=');

--- a/src/main/java/vip/fubuki/playersync/util/LocalJsonUtil.java
+++ b/src/main/java/vip/fubuki/playersync/util/LocalJsonUtil.java
@@ -11,8 +11,15 @@ public class LocalJsonUtil {
         String[] split = s2.split(",");
         for (int i = split.length - 1; i >= 0; i--) {
             String trim = split[i].trim();
-            String[] split1 = trim.split("=");
-            map.put(split1[0],split1[1]);
+
+            // only check for the first "=" as the values also contain additional "="
+            int equalIndex = trim.indexOf('=');
+            if (equalIndex < 0)
+                continue;
+
+            String key = trim.substring(0, equalIndex);
+            String value = trim.substring(equalIndex + 1);
+            map.put(key, value);
         }
         return map;
     }
@@ -24,8 +31,15 @@ public class LocalJsonUtil {
         String[] split = s2.split(",");
         for (int i = split.length - 1; i >= 0; i--) {
             String trim = split[i].trim();
-            String[] split1 = trim.split("=");
-            map.put(Integer.parseInt(split1[0]),split1[1]);
+
+            // only check for the first "=" as the values also contain additional "="
+            int equalIndex = trim.indexOf('=');
+            if (equalIndex < 0)
+                continue;
+
+            String key = trim.substring(0, equalIndex);
+            String value = trim.substring(equalIndex + 1);
+            map.put(Integer.parseInt(key), value);
         }
         return map;
     }

--- a/src/main/java/vip/fubuki/playersync/util/LocalJsonUtil.java
+++ b/src/main/java/vip/fubuki/playersync/util/LocalJsonUtil.java
@@ -2,10 +2,11 @@ package vip.fubuki.playersync.util;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 public class LocalJsonUtil {
-    public static Map<String,String> StringToMap(String param) {
-        Map<String,String> map = new HashMap<>();
+    private static <K> Map<K, String> stringToGenericMap(String param, Function<String, K> keyParser) {
+        Map<K, String> map = new HashMap<>();
         String s1 = param.substring(1,param.length()-1);
         String s2 = s1.trim();
         String[] split = s2.split(",");
@@ -19,28 +20,16 @@ public class LocalJsonUtil {
 
             String key = trim.substring(0, equalIndex);
             String value = trim.substring(equalIndex + 1);
-            map.put(key, value);
+            map.put(keyParser.apply(key), value);
         }
         return map;
     }
 
-    public static Map<Integer,String> StringToEntryMap(String param) {
-        Map<Integer,String> map = new HashMap<>();
-        String s1 = param.substring(1,param.length()-1);
-        String s2 = s1.trim();
-        String[] split = s2.split(",");
-        for (int i = split.length - 1; i >= 0; i--) {
-            String trim = split[i].trim();
+    public static Map<String, String> StringToMap(String param) {
+        return stringToGenericMap(param, Function.identity());
+    }
 
-            // only check for the first "=" as the values also contain additional "="
-            int equalIndex = trim.indexOf('=');
-            if (equalIndex < 0)
-                continue;
-
-            String key = trim.substring(0, equalIndex);
-            String value = trim.substring(equalIndex + 1);
-            map.put(Integer.parseInt(key), value);
-        }
-        return map;
+    public static Map<Integer, String> StringToEntryMap(String param) {
+        return stringToGenericMap(param, Integer::parseInt);
     }
 }


### PR DESCRIPTION
Backport of #93 to `1.20.4`.

### Description
I noticed that base64 encoding seemed to be slower than legacy encoding and realized that our `serializedNbt.equals("B64:e30=")` code never matched, causing it to run through several unnecessary parsing steps later.

This was caused because the `StringToEntryMap` function removed all `=` from the value of the key/value pair within the json.
Assuming that there might be other cases where `=` is used within the value, it might be a lot safer to just check for the first `=` and leave the remaining ones as part of the value.

While working on it, I also simplified it a bit and unified the two mapping functions.

@mlus-asuka I did only some simple testing with 1.20.4, please have a closer look at  the new function if I missed something.