### PR TITLE
log the advancement's data type before altering

### DIFF
--- a/src/main/java/vip/fubuki/playersync/PlayerSync.java
+++ b/src/main/java/vip/fubuki/playersync/PlayerSync.java
@@ -176,7 +176,7 @@ public class PlayerSync {
         if (rsAdvCol.next()) {
             String dataType = rsAdvCol.getString("DATA_TYPE");
             if (!"mediumblob".equalsIgnoreCase(dataType)) {
-                LOGGER.info("Altering player_data table to modify 'advancements' column to MEDIUMBLOB.");
+                LOGGER.info("Altering player_data table to modify 'advancements' column from {} to MEDIUMBLOB.", dataType);
                 JDBCsetUp.executeUpdate("ALTER TABLE " + dbName + ".player_data MODIFY COLUMN advancements MEDIUMBLOB", 1);
             }
         }


### PR DESCRIPTION
it seems that sometimes this is triggered on an existing database. This should help identifying what is happening in these cases.