### PR TITLE
[Backport 1.20.4] log the advancement's data type before altering

### DIFF
--- a/src/main/java/vip/fubuki/playersync/PlayerSync.java
+++ b/src/main/java/vip/fubuki/playersync/PlayerSync.java
@@ -169,7 +169,7 @@ public class PlayerSync {
         if (rsAdvCol.next()) {
             String dataType = rsAdvCol.getString("DATA_TYPE");
             if (!"mediumblob".equalsIgnoreCase(dataType)) {
-                LOGGER.info("Altering player_data table to modify 'advancements' column to MEDIUMBLOB.");
+                LOGGER.info("Altering player_data table to modify 'advancements' column from {} to MEDIUMBLOB.", dataType);
                 JDBCsetUp.executeUpdate("ALTER TABLE " + dbName + ".player_data MODIFY COLUMN advancements MEDIUMBLOB", 1);
             }
         }


### PR DESCRIPTION
Backport of #97 to `1.20.4`.

### Description
it seems that sometimes this is triggered on an existing database. This should help identifying what is happening in these cases.