### PR TITLE
[Backport 1.20.4] make QueryResult AutoClosable

### DIFF
--- a/src/main/java/vip/fubuki/playersync/util/JDBCsetUp.java
+++ b/src/main/java/vip/fubuki/playersync/util/JDBCsetUp.java
@@ -90,6 +90,24 @@ public class JDBCsetUp {
         }
     }
 
-    public record QueryResult(Connection connection, ResultSet resultSet) {
+    public record QueryResult(Connection connection, ResultSet resultSet) implements AutoCloseable {
+        @Override
+        public void close() {
+            if (resultSet != null) {
+                try {
+                    resultSet.close();
+                } catch (SQLException e) {
+                    LOGGER.error("Error closing ResultSet", e);
+                }
+            }
+
+            if (connection != null) {
+                try {
+                    connection.close();
+                } catch (SQLException e) {
+                    LOGGER.error("Error closing Connection", e);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Backport of #99 to `1.20.4`.

### Description
This allows QueryResults to be used within a try() block without explicitely closing them:

```java
try (JDBCsetUp.QueryResult advColCheck = JDBCsetUp.executeQuery(
        "SELECT DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS " +
                "WHERE TABLE_SCHEMA = DATABASE()" +
                "AND TABLE_NAME = 'player_data' " +
                "AND COLUMN_NAME = 'advancements';")) {
    ResultSet rsAdvCol = advColCheck.resultSet();
    if (rsAdvCol.next()) {
        ...
    }
}
```

instead of
```java
JDBCsetUp.QueryResult advColCheck = JDBCsetUp.executeQuery(
        "SELECT DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS " +
                "WHERE TABLE_SCHEMA = DATABASE()" +
                "AND TABLE_NAME = 'player_data' " +
                "AND COLUMN_NAME = 'advancements';"
);
ResultSet rsAdvCol = advColCheck.resultSet();
if (rsAdvCol.next()) {
    ...
}
rsAdvCol.close();
advColCheck.close();
```

I noticed that a few `close()` seem to be missing and I don't think they are intentionally missing.

@mlus-asuka what do you think about my auto-close() implementation? Should this be the intended behaviour?