### PR TITLE
[1.20.1] add new data_version column to server_info table

### DIFF
--- a/src/main/java/vip/fubuki/playersync/PlayerSync.java
+++ b/src/main/java/vip/fubuki/playersync/PlayerSync.java
@@ -2,6 +2,7 @@ package vip.fubuki.playersync;
 
 import com.mojang.logging.LogUtils;
 import com.mysql.cj.jdbc.Driver;
+import net.minecraft.SharedConstants;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -118,28 +119,37 @@ public class PlayerSync {
                         "PRIMARY KEY (`id`)" +
                         ");"
         );
+        // do not modify the create table statement to make sure this code is compatible with older database versions
+        addColumnIfNotExists("server_info", "data_version", "INT NOT NULL DEFAULT 0");
+
         long current = System.currentTimeMillis();
+        int data_version = SharedConstants.getCurrentVersion().getDataVersion().getVersion();
         JDBCsetUp.executeUpdate("""
                 INSERT INTO %s.server_info
                 (
                     id,
                     enable,
+                    data_version,
                     last_update
                 )
                 VALUES (
                     %d,
                     true,
+                    %d,
                     %d
                 )
                 ON DUPLICATE KEY UPDATE
                     id = %d,
                     enable = true,
+                    data_version = %d,
                     last_update = %d;
                 """,
                 dbName,
                 JdbcConfig.SERVER_ID.get(),
+                data_version,
                 current,
                 JdbcConfig.SERVER_ID.get(),
+                data_version,
                 current);
 
         // Create curios table if the Curios mod is loaded


### PR DESCRIPTION
This adds the data_version to the server_info table for all servers to see which version range are being in use.