### PR TITLE
Fixes #138

### DIFF
--- a/src/main/java/vip/fubuki/playersync/sync/ModsSupport.java
+++ b/src/main/java/vip/fubuki/playersync/sync/ModsSupport.java
@@ -150,7 +150,7 @@ public class ModsSupport {
                 for (int i = 0; i < dynStacks.getSlots(); i++) {
                     ItemStack stack = dynStacks.getStackInSlot(i);
                     if (!stack.isEmpty()) {
-                        String serialized = VanillaSync.serialize(stack.serializeNBT().toString());
+                        String serialized = VanillaSync.serialize(VanillaSync.serializeNBT(stack).toString());
                         flatMap.put(slotType + ":" + i, serialized);
                     }
                 }


### PR DESCRIPTION
相关修改说明:
使用你所写的带有版本校验的自定义serializeNBT方法，而不是Forge内的serializeNBT方法，以通过版本检测

### **_再次重申，由于不清楚一些联动mod，保险期间请您再次检查storeSophisticatedBackpacks方法_**