### PR TITLE
[Backport 1.20.4] Fixes #140

### DIFF
--- a/src/main/java/vip/fubuki/playersync/PlayerSync.java
+++ b/src/main/java/vip/fubuki/playersync/PlayerSync.java
@@ -184,6 +184,11 @@ public class PlayerSync {
         rsAdvCol.close();
         // ----- END NEW BLOCK -----
 
+        try {
+            JDBCsetUp.executeUpdate("UPDATE player_data SET online=0 WHERE last_server=" + JdbcConfig.SERVER_ID.get() +" AND online=1 LIMIT 1000");
+        } catch (Exception e) {
+            LOGGER.error("An exception occurred while trying change wrong player-status\n" + e.getMessage());
+        }
         LOGGER.info("PlayerSync is ready!");
     }
 


### PR DESCRIPTION
Backport of #141 to `1.20.4`.

### Description
修复细节:
在服务器每次启动后，自动重置出现问题的玩家数据
即在player_data中寻找上次在本服务器并且仍然"在线"的玩家，并将在线状态设为离线